### PR TITLE
Fix case typo on accessProvider include.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2,7 +2,7 @@
 
 let Review = require('./reviewApi/review');
 let Resources = require('./resourcesApi/resources');
-let AccessProvider = require('./AccessProvider');
+let AccessProvider = require('./accessProvider');
 let Request = require('./requestHelper');
 let ProductReview = require('./productReviewApi/productReview');
 let Invitation = require('./invitationApi/invitation');


### PR DESCRIPTION
Fix case typo on accessProvider include which causes an error when importing the trustpilot library on Linux.